### PR TITLE
Fix paddle speed and boundary overflow

### DIFF
--- a/Engine/Game/Game.cpp
+++ b/Engine/Game/Game.cpp
@@ -122,8 +122,10 @@ void Game::Update(float dt) {
 
 	m_Physics.Step(dt);
 	const Uint8* keys = SDL_GetKeyboardState(nullptr);
-	m_PaddleL.Update(keys, dt, SDL_SCANCODE_W, SDL_SCANCODE_S, 800.f);
-	m_PaddleR.Update(keys, dt, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, 800.f);
+        m_PaddleL.Update(keys, dt, SDL_SCANCODE_W, SDL_SCANCODE_S, 800.f,
+                         0.f, static_cast<float>(m_WindowHeight));
+        m_PaddleR.Update(keys, dt, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, 800.f,
+                         0.f, static_cast<float>(m_WindowHeight));
 	
 }
 

--- a/Engine/Game/Paddle.cpp
+++ b/Engine/Game/Paddle.cpp
@@ -11,19 +11,34 @@ void Paddle::Init(PhysicsSystem& phys, float px, float py) {
 }
 
 void Paddle::Update(const Uint8* keys, float dt,
-                    SDL_Scancode keyUp, SDL_Scancode keyDown, float speed) {
+                    SDL_Scancode keyUp, SDL_Scancode keyDown, float speed,
+                    float minY, float maxY) {
         int dir = 0;
-	if (keys[keyUp]) dir = -1;
-	if (keys[keyDown]) dir = 1;
+        if (keys[keyUp]) dir = -1;
+        if (keys[keyDown]) dir = 1;
 
-	if (dir != 0) {
-		float impulse = dir * speed * dt;
-		m_Body->ApplyLinearImpulseToCenter({ 0,impulse }, true);
-	}
+        // apply constant velocity instead of impulses to avoid acceleration
+        b2Vec2 vel = m_Body->GetLinearVelocity();
+        vel.y = dir * (speed / PPM);
+        m_Body->SetLinearVelocity(vel);
 
-	b2Vec2 pos = m_Body->GetPosition();
-	m_Dst.x = static_cast<int>(pos.x * PPM - m_Dst.w * 0.5f);
-	m_Dst.y = static_cast<int>(pos.y * PPM - m_Dst.h * 0.5f);
+        b2Vec2 pos = m_Body->GetPosition();
+
+        float halfH = m_Dst.h * 0.5f;
+        float minPos = (minY + halfH) / PPM;
+        float maxPos = (maxY - halfH) / PPM;
+        if (pos.y < minPos) {
+                pos.y = minPos;
+                m_Body->SetTransform(pos, 0);
+                m_Body->SetLinearVelocity({0,0});
+        } else if (pos.y > maxPos) {
+                pos.y = maxPos;
+                m_Body->SetTransform(pos, 0);
+                m_Body->SetLinearVelocity({0,0});
+        }
+
+        m_Dst.x = static_cast<int>(pos.x * PPM - m_Dst.w * 0.5f);
+        m_Dst.y = static_cast<int>(pos.y * PPM - m_Dst.h * 0.5f);
 
 }
 

--- a/Engine/Game/Paddle.h
+++ b/Engine/Game/Paddle.h
@@ -8,7 +8,8 @@ public:
     void Init(PhysicsSystem& phys, float px, float py);
     // keyUp and keyDown indicate which keyboard scancodes move the paddle
     void Update(const Uint8* keys, float dt,
-                SDL_Scancode keyUp, SDL_Scancode keyDown, float speed);
+                SDL_Scancode keyUp, SDL_Scancode keyDown, float speed,
+                float minY, float maxY);
     void Draw(RenderQueue& rq, SDL_Texture* tex, int z);
 private:
     b2Body* m_Body = nullptr;


### PR DESCRIPTION
## Summary
- prevent paddles from accelerating endlessly
- clamp paddle position within the screen

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ace84e7548330b66c579b1154cd0d